### PR TITLE
Fix setup.py so that meta.yaml generates properly for conda build.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,11 +12,10 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, "README.md"), encoding="utf-8") as f:
     long_description = f.read()
 
-
 setup(
     name="plotly_express",
     version="0.1.1",
-    description="Plotly Express: a high level wrapper for Plotly.py",
+    description="Plotly Express - a high level wrapper for Plotly.py",
     long_description=long_description,
     long_description_content_type="text/markdown",
     url="https://github.com/plotly/plotly_express",


### PR DESCRIPTION
Being an Anaconda distribution fan, I ran `conda skeleton pypi plotly_express` and then `conda build plotly_express`. The build step failed, because the `meta.yaml` file that got generated had a double colon in the `description` field. I changed the `:` to a `-` and it built perfectly. 