### PR TITLE
Add conda recipe

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,0 +1,32 @@
+{% set sdata = load_setup_py_data() %}
+
+package:
+  name: plotly_express
+  version: {{ sdata['version'] }}
+
+source:
+  path: ..
+
+build:
+  noarch: python
+  script: "{{ PYTHON }} -m pip install . --no-deps --ignore-installed --no-cache-dir -q"
+
+requirements:
+  build:
+    - python
+    - pip
+  run:
+    - python
+    {% for dep in sdata.get('install_requires',{}) %}
+    - {{ dep }}
+    {% endfor %}
+
+test:
+  imports:
+    - plotly_express
+
+about:
+  home: {{ sdata['url'] }}
+  summary: {{ sdata['description'] }}
+  license: {{ sdata['license'] }}
+  license_file: LICENSE.txt

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ setup(
     url="https://github.com/plotly/plotly_express",
     author="Nicolas Kruchten",
     author_email="nicolas@plot.ly",
+    license='MIT',
     classifiers=[
         "Development Status :: 4 - Beta",
         "Topic :: Scientific/Engineering :: Visualization",
@@ -32,6 +33,6 @@ setup(
         "pandas>=0.20.0",
         "plotly>=3.7.1",
         "statsmodels>=0.9.0",
-        "scipy >= 0.14",
+        "scipy>=0.14",
     ],
 )


### PR DESCRIPTION
This PR adds a conda recipe for plotly_express.  It uses Jinja2 templating to automatically pull in the version, description, and dependencies from the setup.py file so it should be pretty low maintenance.

I uploaded the output of this recipe to the plotly anaconda channel at https://anaconda.org/plotly/plotly_express.

To build the conda package
```
$ conda install conda-build
$ conda build recipe/
```

To upload to the plotly anaconda channel
```
$ conda install anaconda-client
$ anaconda login
$ anaconda upload ... # The path that was output by conda build above
```

