### PR TITLE
expose OLS fit results

### DIFF
--- a/plotly_express/__init__.py
+++ b/plotly_express/__init__.py
@@ -31,7 +31,12 @@ from ._chart_types import (  # noqa: F401
     density_contour,
 )
 
-from ._core import ExpressFigure, set_mapbox_access_token, defaults  # noqa: F401
+from ._core import (  # noqa: F401
+    ExpressFigure,
+    set_mapbox_access_token,
+    defaults,
+    get_trendline_results,
+)
 
 from . import data, colors  # noqa: F401
 
@@ -61,5 +66,6 @@ __all__ = [
     "data",
     "colors",
     "set_mapbox_access_token",
+    "get_trendline_results",
     "ExpressFigure",
 ]


### PR DESCRIPTION
This PR adds `px.get_trendline_results(fig)` which will return a `pandas` data frame containing nicely-indexed `statsmodel` results from any OLS trendlines.

here's what it looks like:

![image](https://user-images.githubusercontent.com/203523/57305566-49b99e80-70af-11e9-931e-5a152e7135ed.png)
